### PR TITLE
Update fzf's release page

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -3,17 +3,27 @@
 set -e
 set -o pipefail
 
-releases_path=https://api.github.com/repos/junegunn/fzf-bin/releases
-cmd="curl -s"
-if [ -n "$GITHUB_API_TOKEN" ]; then
-  cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
-fi
-
-cmd="$cmd $releases_path"
 
 function sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-echo $(eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"//;s/\",//' | sort_versions)
+function fetch_versions() {
+  releases_path=$1
+  cmd="curl -s"
+  if [ -n "$GITHUB_API_TOKEN" ]; then
+    cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
+  fi
+
+  cmd="$cmd $releases_path"
+
+  echo $(eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"//;s/\",//' | sort_versions)
+}
+
+# We're purposefully sorting each list individually instead of the global list because one of the version 
+# the old list is returning is "alpha" and we want that version to appear before the newer versions
+old_tags=$(fetch_versions "https://api.github.com/repos/junegunn/fzf-bin/releases")
+new_tags=$(fetch_versions "https://api.github.com/repos/junegunn/fzf/releases")
+all_tags=("${old_tags[@]}" "${new_tags[@]}")
+echo "${all_tags[@]}"


### PR DESCRIPTION
Since 0.24.0, new releases are available only in junegunn/fzf/releases.