### PR TITLE
Add function to test for fzf versions greater than or equal to 0.54.0 and append a "v" prefix

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -8,6 +8,27 @@ fail() {
   exit 1
 }
 
+# Function to compare versions
+vercomp() {
+  local version="$1"
+  local target="0.54.0"
+
+  # Convert version strings to arrays
+  IFS='.' read -r -a version_parts <<< "$version"
+  IFS='.' read -r -a target_parts <<< "$target"
+
+  # Compare each part of the version
+  for ((i = 0; i < 3; i++)); do
+    if (( version_parts[i] > target_parts[i] )); then
+      return 0
+    elif (( version_parts[i] < target_parts[i] )); then
+      return 1
+    fi
+  done
+
+  return 0
+}
+
 install_fzf() {
   local install_type=$1
   local version=$2
@@ -17,9 +38,13 @@ install_fzf() {
     fail "asdf-fzf supports release installs only"
   fi
 
-  local download_url
-  download_url="https://github.com/junegunn/fzf/archive/${version}.tar.gz"
-  local source_path="${install_path}/${version}.tar.gz"
+  if vercomp "$version"; then
+    local download_url="https://github.com/junegunn/fzf/archive/v${version}.tar.gz"
+    local source_path="${install_path}/v${version}.tar.gz"
+  else
+    local download_url="https://github.com/junegunn/fzf/archive/${version}.tar.gz"
+    local source_path="${install_path}/${version}.tar.gz"
+  fi
 
   (
     echo "∗ Downloading and installing fzf..."


### PR DESCRIPTION
Per the [fzf 0.54.0 changelog](https://github.com/junegunn/fzf/releases/tag/v0.54.0)

>New tags will have v prefix so that they are available on https://proxy.golang.org/

This pull requests introduces a new function `vercomp` to check if the install version is greater than or equal to 0.54.0. If so, the "v" prefix is added before the version in the `download_url` and `source_path` variables.

This addresses issue #2.