### PR TITLE
Remove new v-prefix in versions returned by list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -18,7 +18,7 @@ function fetch_versions() {
 
   cmd="$cmd $releases_path"
 
-  echo $(eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"//;s/\",//' | sort_versions)
+  echo $(eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"//;s/\",//;s/^v//' | sort_versions)
 }
 
 # We're purposefully sorting each list individually instead of the global list because one of the version 


### PR DESCRIPTION
This is a follow-up of #2 and #3, more specifically https://github.com/kompiro/asdf-fzf/pull/3#issuecomment-2326668436.

As far as I can tell, #3 adds the new `v`-prefix twice: It is returned by `list-all` to `asdf`. And it is added in the new logic in `install` for versions higher than `0.54.0`. Thus, `asdf install fzf v0.55.0` fails on current master.
This PR simply removes the `v`-prefix in `list-all`, relying on the new logic in `install` to re-introduce it on download. As a nice side effect, `asdf latest fzf` works again.
Not sure if this is the smartest fix though.